### PR TITLE
Add aaisp2mqtt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ You can then run `helm search nikdoof` to see the charts.
 
 See [charts folder](./charts) for a complete list.
 
-* [aaisp-to-mqtt](./charts/aaisp-to-mqtt) - A tool to pull information from [Andrews & Arnold](https://www.aa.net.uk/) CHAOSv2 API and output to MQTT
+* [aaisp2mqtt](./charts/aaisp2mqtt) - A tool to pull information from [Andrews & Arnold](https://www.aa.net.uk/) CHAOSv2 API and output to MQTT
 * [calibre-web](./charts/calibre-web) - Web app for browsing, reading and downloading eBooks stored in a Calibre database
-* [deluge](./charts/deluge) - Deluge torrent client 
+* [deluge](./charts/deluge) - Deluge torrent client
 
 
 ## License

--- a/charts/aaisp2mqtt/.helmignore
+++ b/charts/aaisp2mqtt/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/aaisp2mqtt/Chart.yaml
+++ b/charts/aaisp2mqtt/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+appVersion: "0.3.0"
+description: Pulls data from the AAISP CHAOSv2 API into MQTT
+name: aaisp2mqtt
+version: 0.3.0
+keywords:
+  - aaisp
+  - mqtt
+home: https://github.com/nikdoof/aaisp2mqtt
+sources:
+  - https://hub.docker.com/r/nikdoof/aaisp2mqtt/
+  - https://github.com/natm/aaisp2mqtt
+maintainers:
+  - name: nikdoof
+    email: andy@tensixtyone.com

--- a/charts/aaisp2mqtt/ci/existingsecret-values.yaml
+++ b/charts/aaisp2mqtt/ci/existingsecret-values.yaml
@@ -1,0 +1,4 @@
+mqtt:
+  broker: localhost
+
+existingSecretName: aaisp2mqtt-secret

--- a/charts/aaisp2mqtt/ci/homeassistant-values.yaml
+++ b/charts/aaisp2mqtt/ci/homeassistant-values.yaml
@@ -1,0 +1,9 @@
+aaisp:
+  username: test1@a
+  password: TesttestTest
+
+mqtt:
+  broker: localhost
+
+homeassistant:
+  enabled: true

--- a/charts/aaisp2mqtt/ci/test-values.yaml
+++ b/charts/aaisp2mqtt/ci/test-values.yaml
@@ -1,0 +1,6 @@
+aaisp:
+  username: test1@a
+  password: TesttestTest
+
+mqtt:
+  broker: localhost

--- a/charts/aaisp2mqtt/templates/_helpers.tpl
+++ b/charts/aaisp2mqtt/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aaisp2mqtt.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "aaisp2mqtt.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aaisp2mqtt.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "aaisp2mqtt.labels" -}}
+app.kubernetes.io/name: {{ include "aaisp2mqtt.name" . }}
+helm.sh/chart: {{ include "aaisp2mqtt.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "aaisp2mqtt.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "aaisp2mqtt.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/aaisp2mqtt/templates/cronjob.yaml
+++ b/charts/aaisp2mqtt/templates/cronjob.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "aaisp2mqtt.fullname" . }}-cronjob
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- range $key, $value := .Values.deploymentAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "aaisp2mqtt.name" . }}
+    helm.sh/chart: {{ include "aaisp2mqtt.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ include "aaisp2mqtt.name" . }}
+spec:
+  schedule: {{ .Values.cronjob.schedule | quote }}
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
+  concurrencyPolicy: Forbid
+  {{- if .Values.cronjob.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ .Values.cronjob.startingDeadlineSeconds }}
+  {{- end }}
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: {{ include "aaisp2mqtt.name" . }}
+            helm.sh/chart: {{ include "aaisp2mqtt.chart" . }}
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            app.kubernetes.io/managed-by: {{ include "aaisp2mqtt.name" . }}
+        spec:
+          restartPolicy: Never
+          {{- if .Values.image.pullSecrets }}
+          imagePullSecrets:
+          {{- range .Values.image.pullSecrets }}
+            - name: {{ . }}
+          {{- end }}
+          {{- end }}
+          containers:
+          - name: {{ .Chart.Name }}
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            resources:
+{{ toYaml .Values.resources | indent 16 }}
+            env:
+              - name: AAISP_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ default "aaisp2mqtt-secret" .Values.existingSecretName }}
+                    key: aaisp.username
+              - name: AAISP_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ default "aaisp2mqtt-secret" .Values.existingSecretName }}
+                    key: aaisp.password
+              - name: MQTT_BROKER
+                value: {{ .Values.mqtt.broker }}
+              - name: MQTT_PORT
+                value: "{{ default 1883 .Values.mqtt.port }}"
+            {{- if .Values.mqtt.authenticated }}
+              - name: MQTT_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ default "aaisp2mqtt-secret" .Values.existingSecretName }}
+                    key: mqtt.username
+              - name: MQTT_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ default "aaisp2mqtt-secret" .Values.existingSecretName }}
+                    key: mqtt.password
+            {{- end }}
+              - name: MQTT_TOPIC_PREFIX
+                value: {{ default "aaisp" .Values.mqtt.topicPrefix }}
+            {{- if .Values.homeassistant.enabled }}
+              - name: HOMEASSISTANT_ENABLED
+                value: '{{ .Values.homeassistant.enabled }}'
+              {{- if .Values.homeassistant.discoveryPrefix }}
+              - name: HOMEASSISTANT_DISCOVERY_PREFIX
+                value: {{ .Values.homeassistant.discoveryPrefix }}
+              {{- end }}
+            {{- end }}
+    {{- with .Values.nodeSelector }}
+          nodeSelector:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+          affinity:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+          tolerations:
+{{ toYaml . | indent 12 }}:
+    {{- end }}

--- a/charts/aaisp2mqtt/templates/secrets.yaml
+++ b/charts/aaisp2mqtt/templates/secrets.yaml
@@ -1,0 +1,20 @@
+---
+{{- if not (.Values.existingSecretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aaisp2mqtt-secret
+  labels:
+    app.kubernetes.io/name: {{ include "aaisp2mqtt.name" . }}
+    helm.sh/chart: {{ include "aaisp2mqtt.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ include "aaisp2mqtt.name" . }}
+type: Opaque
+data:
+  aaisp.username: {{ .Values.aaisp.username | b64enc }}
+  aaisp.password: {{ .Values.aaisp.password | b64enc }}
+  {{- if .Values.mqtt.authenticated }}
+  mqtt.username: {{ .Values.mqtt.username | b64enc }}
+  mqtt.password: {{ .Values.mqtt.password | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/aaisp2mqtt/values.yaml
+++ b/charts/aaisp2mqtt/values.yaml
@@ -1,0 +1,60 @@
+# Default values for aaisp2mqtt.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nikdoof/aaisp2mqtt
+  tag: 0.3.0
+  pullPolicy: IfNotPresent
+  # imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+## Use a pre-existing secret for login information
+##
+# existingSecretName: existing-secret
+
+## Connection details
+##
+aaisp: {}
+  # username: user1@a
+  # password: password
+
+mqtt:
+  # broker: localhost
+  port: 1883
+  authenticated: false
+  # username: kube
+  # password: kube
+  # topicPrefix: aaisp
+
+homeassistant:
+  enabled: false
+  # discoveryPrefix: homeassistant
+
+cronjob:
+  schedule: "*/10 * * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  # startingDeadlineSeconds: 10
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Replacement for aaisp-to-mqtt, which was a small build fork of the original project. This is now a true fork with new features. To avoid conflicting the project was renamed and a new module created.