### PR TITLE
Bump aaisp2mqtt to v0.3.1 by default

### DIFF
--- a/charts/aaisp2mqtt/Chart.yaml
+++ b/charts/aaisp2mqtt/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.3.0"
+appVersion: "0.3.1"
 description: Pulls data from the AAISP CHAOSv2 API into MQTT
 name: aaisp2mqtt
-version: 0.3.1
+version: 0.3.2
 keywords:
   - aaisp
   - mqtt

--- a/charts/aaisp2mqtt/values.yaml
+++ b/charts/aaisp2mqtt/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: nikdoof/aaisp2mqtt
-  tag: 0.3.0
+  tag: 0.3.1
   pullPolicy: IfNotPresent
   # imagePullSecrets: []
 


### PR DESCRIPTION
v0.3.0 had an issue that could result in aaisp2mqtt not pushing all data to MQTT. This change bumps the default version of aaisp2mqtt to v0.3.1 to avoid this.