### PR TITLE
[vsphere-influxdb-go] Fix default configmap

### DIFF
--- a/charts/vsphere-influxdb-go/Chart.yaml
+++ b/charts/vsphere-influxdb-go/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.5"
 description: Collect VMware vCenter and ESXi performance metrics and send them to InfluxDB
 name: vsphere-influxdb-go
-version: 0.2.0
+version: 0.2.1
 keywords:
   - vsphere
   - influxdb

--- a/charts/vsphere-influxdb-go/values.yaml
+++ b/charts/vsphere-influxdb-go/values.yaml
@@ -45,8 +45,8 @@ config:
   Domain: ".lab"
   RemoveHostDomainName: false
   Interval: 60
-  VCenters: {}
-  InfluxDB: {}
+  VCenters: []
+  InfluxDB: []
   Metrics:
   - ObjectType:
     - VirtualMachine


### PR DESCRIPTION
The chart, by default, produces an invalid configmap and causes the job to fail.